### PR TITLE
Update to conda_auto_env.sh

### DIFF
--- a/conda_auto_env.sh
+++ b/conda_auto_env.sh
@@ -14,7 +14,9 @@
 function conda_auto_env() {
   if [ -e "environment.yml" ]; then
     # echo "environment.yml file found"
-    ENV=$(head -n 1 environment.yml | cut -f2 -d ' ')
+    # Get environment name associated with 'name' variable in file
+    ENV=`grep 'name:' environment.yml | tail -n1 | awk '{ print $2}'`
+
     # Check if you are already in the environment
     if [[ $PATH != *$ENV* ]]; then
       # Check if the environment exists

--- a/conda_auto_env.sh
+++ b/conda_auto_env.sh
@@ -26,8 +26,28 @@ function conda_auto_env() {
       else
         # Create the environment and activate
         echo "Conda env '$ENV' doesn't exist."
-        conda env create -q
-        conda activate $ENV
+
+        while true; do
+            select choice in CREATE IGNORE
+            do
+                echo "$REPLY : $choice"
+                break
+            done
+
+            case $choice in
+                "CREATE" )
+                    echo "Creating new conda environment from 'environment.yml' file found in folder..";
+                    sleep 2;
+                    conda env create -q;
+                    conda activate $ENV;
+                    break ;;
+                "IGNORE" )
+                    echo "Ceasing creation of new conda environment";
+                    break ;;
+                * )
+                    echo "Please Choose Option 1, or 2" ;;
+            esac
+        done
       fi
     fi
   fi


### PR DESCRIPTION
Closes #1 

- Sometimes I have projects which actually have comments in the headings of the
`environment.yml` file which means the previous code was unable to find `"name: "`
easily. Therefore I found using awk to be a better alternative.

- Occasionally I change directory into a project which
contains an `environment.yml` file pertaining to a conda environment I do not
have, but I do not actually want to install it. So, I have added a user input
question to determine if they want to create an environment or not.